### PR TITLE
Improve implementation to support encoding and Drupal's SHA-512 '$S$' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,7 @@
 
 A password hash provider to handle PHPass passwords inside Keycloak.
 
-Cannot encrypt passwords, can only verify them.
-
-The primary purpose is to smoothly migrate from legacy databases with PHPass hashes.
-
-You should set Authentication->Policies->Hashing Algorithm to `pbkdf2-sha256`.
-Keycloak will then automatically replace your legacy PHPass hashes
-with pbkdf2-sha256 hashes at the first login of the corresponding user.
+Makes it possible to migrate users and their existing PHPass hashed passwords from legacy databases.
 
 ## Build JAR
 
@@ -17,16 +11,18 @@ with pbkdf2-sha256 hashes at the first login of the corresponding user.
 ```
 
 ## Install
-Copy the jar file (`./build/libs`) to the keycloak providers directory.
 
-You need to restart Keycloak.
+Copy the jar file (from `./build/libs`) to the keycloak providers directory. In the default Docker image this is at `/opt/keycloak/providers/`
 
-## How test.
-Take a user with existing credentials, and modify them to be PHPass credentials.
+Then restart Keycloak.
 
-For example,
-* Open the database's `credential` table.
-* Locate the user's row.
-* In the `secret_data` column, set `value` to the full `$P$...` password hash.
-* In the `credential_data` column, set `algorithm` to `phpass`.
-* You need to restart Keycloak to clear its caches.
+## Migrate Hashes into Keycloak
+
+One strategy would be to build a script around these calls to import your hashes:
+
+```shell
+TOKEN=`curl --location --request POST 'https://keycloak.example.com/realms/master/protocol/openid-connect/token' --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'username=admin' --data-urlencode 'password=1234' --data-urlencode 'grant_type=password' --data-urlencode 'client_id=admin-cli' | jq -r '.access_token'`
+
+# The `hashedSaltedValue` below corresponds to the password: "test"
+curl 'https://keycloak.example.com/admin/realms/example_org/users/28e6ad26-41c6-4e5f-bc88-225cebb1cb61' -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" --data '{"requiredActions": ["UPDATE_PASSWORD"], "credentials": [ { "algorithm": "phpass", "hashedSaltedValue": "$S$Eph.xQb59uZylAYxOl4XfXelW/XWfTLLarPrfcS8bw33Rn5J9y2K", "hashIterations": 16, "type": "password", "salt":""}]}'
+```

--- a/src/main/java/com/github/fjf2002/keycloak/phpass/PHPassPasswordHashProviderFactory.java
+++ b/src/main/java/com/github/fjf2002/keycloak/phpass/PHPassPasswordHashProviderFactory.java
@@ -8,10 +8,11 @@ import org.keycloak.models.KeycloakSessionFactory;
 
 public class PHPassPasswordHashProviderFactory implements PasswordHashProviderFactory {
 	public static final String ID = "phpass";
+	public static final int DEFAULT_ITERATIONS_LOG_BASE_2 = 16;
 
 	@Override
 	public PasswordHashProvider create(KeycloakSession session) {
-		return new PHPassPasswordHashProvider();
+		return new PHPassPasswordHashProvider(ID, DEFAULT_ITERATIONS_LOG_BASE_2);
 	}
 
 	@Override

--- a/src/main/java/com/github/fjf2002/keycloak/phpass/PHPassTool.java
+++ b/src/main/java/com/github/fjf2002/keycloak/phpass/PHPassTool.java
@@ -3,6 +3,7 @@ package com.github.fjf2002.keycloak.phpass;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 
 /**
@@ -35,6 +36,8 @@ import java.util.Arrays;
 public final class PHPassTool {
 
 	private static String itoa64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+	private static int MAX_HASH_LENGTH = 55;
 
 	private PHPassTool() {
 	}
@@ -74,13 +77,32 @@ public final class PHPassTool {
 		return output;
 	}
 
-	private static String cryptPrivate(String password, String setting) {
+	public static String generateSettings(int iterationsLogBase2) {
+		String output = "$S$";
+		// Convert the log base2 iteration count to a base64 character representation
+		output += itoa64.charAt(iterationsLogBase2);
+		// Generate the 6 random bytes of salt for a portable phpass hash
+		byte[] saltyBytes = new byte[6];
+		try {
+			SecureRandom.getInstanceStrong().nextBytes(saltyBytes);
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException(e);
+		}
+		output += encode64(saltyBytes, 6);
+		return output;
+	}
+
+	public static String hash(String password, String setting) {
 		if (((setting.length() < 2) ? setting : setting.substring(0, 2)).equalsIgnoreCase("*0")) {
 			throw new RuntimeException("Not a PHPass hash");
 		}
 		String id = (setting.length() < 3) ? setting : setting.substring(0, 3);
-		if (!(id.equals("$P$") || id.equals("$H$"))) {
+		if (!(id.equals("$P$") || id.equals("$H$") || id.equals("$S$"))) {
 			throw new RuntimeException("Not a PHPass hash");
+		}
+		String alg = "MD5";
+		if (id.equals("$S$")) {
+			alg = "SHA-512";
 		}
 		int countLog2 = itoa64.indexOf(setting.charAt(3));
 		if (countLog2 < 7 || countLog2 > 30) {
@@ -93,7 +115,7 @@ public final class PHPassTool {
 		}
 
 		try {
-			final MessageDigest md = MessageDigest.getInstance("MD5");
+			final MessageDigest md = MessageDigest.getInstance(alg);
 			final byte[] pass = stringToUtf8Bytes(password);
 			byte[] hash = md.digest(stringToUtf8Bytes(salt + password));
 			do {
@@ -103,7 +125,11 @@ public final class PHPassTool {
 				hash = md.digest(t);
 			} while (--count > 0);
 			String output = setting.substring(0, 12);
-			output += encode64(hash, 16);
+			final int len = hash.length;
+			output += encode64(hash, len);
+			if (output.length() > MAX_HASH_LENGTH) {
+				output = output.substring(0, MAX_HASH_LENGTH);
+			}
 			return output;
 		} catch (NoSuchAlgorithmException e) {
 			throw new RuntimeException(e);
@@ -116,6 +142,6 @@ public final class PHPassTool {
 	}
 
 	public static boolean checkPassword(String password, String storedHash) {
-		return cryptPrivate(password, storedHash).equals(storedHash);
+		return hash(password, storedHash).equals(storedHash);
 	}
 }


### PR DESCRIPTION
Thanks for creating this password hash provider @fjf2002!

To work for my use-case I needed to be able to import Drupal's hashes which use a modified PHPass `$S$` SHA-512 mode. It was also useful for testing to have the ability to encode passwords so I added that too. (Though it is still up to the wise sysadmin to migrate away from the PHPass hashing to the superior `pbkdf2-sha256` in good time.)

Support for Drupal's SHA-512 password hashing is roughly based on the description at http://joncave.co.uk/2011/01/password-storage-in-drupal-and-wordpress/ and details from https://github.com/drupal/drupal/blob/3515f040ae71496c4e4387e44fa2afd963762252/core/lib/Drupal/Core/Password/PhpassHashedPasswordBase.php